### PR TITLE
ESLint tweaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,11 +22,17 @@
         "project-structure/config-path": "project-structure.json"
     },
 	"rules": {
+		"no-irregular-whitespace": "off",
 		"project-structure/file-structure": "error",
-		"indent": [
-			"warn",
-			"tab"
-		],
+		"indent": ["error", "tab", {
+			"SwitchCase": 1,
+			"FunctionExpression": {
+				"parameters": 1,
+				"body": 1
+			},
+			"MemberExpression": 1,
+			"offsetTernaryExpressions": true
+		}],
 		"quotes": [
 			"warn",
 			"single"
@@ -55,6 +61,7 @@
 		"@typescript-eslint/no-var-requires": "off",
 		"@typescript-eslint/no-inferrable-types": "off",
 		"@typescript-eslint/ban-ts-comment": "off",
+		"@typescript-eslint/no-unused-vars": "warn",
 		"react-refresh/only-export-components": [
 			"warn",
 			{ "allowConstantExport": true }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "lint:structure": "eslint --parser ./node_modules/eslint-plugin-project-structure/dist/parser.js --rule project-structure/file-structure:error --ext .js,.jsx,.ts,.tsx,.html,.css,.svg,.png,.jpg,.json,.md .",
+    "lint": "eslint . --ext ts,tsx,js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "lint:structure": "eslint --parser ./node_modules/eslint-plugin-project-structure/dist/parser.js --rule project-structure/file-structure:error --ext .js,.jsx,.ts,.tsx,.html,.css,.svg,.json,.md,.mdx .",
     "preview": "vite preview",
     "test:unit": "jest"
   },


### PR DESCRIPTION
- Turn off the automatic "no-irregular-whitespace" rule that seems unnecessary yet problematic 
- Add detail to indent rules so the auto-fix will indent things a bit more neatly and not allow extra or missing indents (e.g., function body should be one indent in from the lines that open and close the function declaration)
- Remove image extensions from the structure check because that runs the regular lint as well, tries to interpret them as code, and has a bad time
- Add `js` and `jsx` extensions to the base check, because some people aren't using TypeScript
- Add auto-fix script to `package.json`